### PR TITLE
Adding package-lock.json to the git ignore list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 config.json
+package-lock.json


### PR DESCRIPTION
This is to prevent people from having to execute `rm -rf package-lock.json` after cloning the repo.